### PR TITLE
Fix automatically upgrading to the latest version.

### DIFF
--- a/sagetv-base/init.d/20-upgrade-sagetv
+++ b/sagetv-base/init.d/20-upgrade-sagetv
@@ -6,7 +6,7 @@ VERSION=${VERSION:-latest}
 # SageTV Version
 SAGE_VERSION=""
 if [ "${VERSION}" = "latest" ] ; then
-    SAGE_VERSION=`curl https://dl.bintray.com/opensagetv/sagetv/sagetv/ | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\).*$/\1/' | egrep -e '9\.[0-9]+' | sort | tail -1`
+    SAGE_VERSION=`curl https://dl.bintray.com/opensagetv/sagetv/sagetv/ | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\).*$/\1/' | egrep -e '9\.[0-9]+' | sort -V | tail -1`
 else
     SAGE_VERSION=${VERSION}
 fi


### PR DESCRIPTION
I noticed when a new version was posted last weekend that when I restarted my container, it still thinks the latest version is 9.0.9.441. The problem appears to be when sorting, the sort is not version aware. That makes '9.0.9.' come after '9.0.11' and breaks this way of getting the latest version. I just added -V to sort which makes it version aware and now it selects the right version.

Alternatively the following command could also be used:

```curl -L https://bintray.com/opensagetv/sagetv/SageTV/_latestVersion | egrep -o '\/opensagetv\/sagetv\/SageTV\/9\.[0-9]*\.[0-9]*\.[0-9]*' | tail -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\).*$/\1/'```

This changes the mechanics of the version checking function to use the latest version redirect link that always works on Bintray. It also makes sure it's coming from an expected link in case the page happens to have other version numbers on it for some reason that match the the SageTV version format. I'm mentioning this as an alternative if for some reason we find another problem with versions being sorted incorrectly.